### PR TITLE
GRID-313: Sort only tree column's expandable rows

### DIFF
--- a/js/DataSourceTreeview.js
+++ b/js/DataSourceTreeview.js
@@ -44,9 +44,10 @@ var DataSourceTreeview = DataSourceIndexed.extend('DataSourceTreeview', {
 
         r = this.getRowCount();
         if (this.joined) {
-            // treeviewSorter needs to know following for access by each DataSourceSorter it creates:
+            // DataSourceTreeviewSorter needs to know following for access by each DataSourceDepthSorter it creates:
             this.dataSource.idColumn = this.idColumn;
             this.dataSource.parentIdColumn = this.parentIdColumn;
+            this.dataSource.treeColumn = this.treeColumn;
 
             // mutate data row with __DEPTH (all rows) and __EXPANDED (all "parent" rows)
             var idColumnName = this.idColumn.name,

--- a/js/DataSourceTreeviewSorter.js
+++ b/js/DataSourceTreeviewSorter.js
@@ -24,7 +24,7 @@ var DataSourceTreeviewSorter = DataSourceSorterComposite.extend('DataSourceTreev
 
             this.sorts.forEach(function(sortSpec) {
                 for (depth = deepest; depth >= 0; --depth) {
-                    each = new DataSourceDepthSorter(each, self.idColumn, self.parentIdColumn);
+                    each = new DataSourceDepthSorter(each, self);
                     each.sortOn(sortSpec.columnIndex, sortSpec.direction, depth);
                 }
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-analytics",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Data transformations on arrays of congruent JavaScript objects.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Essentially, added `treeColumnIndex` and `isTreeColumn` in DataSourceDepthSorter.

Calling this a bug now as it is clear to me now that there was no use case for the previous behavior.